### PR TITLE
Flag the loader as cacheable

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var properties = require("properties");
  * on npm: https://www.npmjs.com/package/properties
  */
 module.exports = function (content) {
+  this.cacheable();
+  
   var callback = this.async();
   properties.parse(content, function (err, result) {
     if (err) {


### PR DESCRIPTION
Mark the loader as [cacheable](https://webpack.github.io/docs/how-to-write-a-loader.html#flag-itself-cacheable-if-possible).
